### PR TITLE
Updated Vagrant and ScaleIO package version to be dynamic

### DIFF
--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -27,10 +27,13 @@ secondmdmip = "#{network}.13"
 clusterinstall = "True" #If True a fully working ScaleIO cluster is installed. False mean only IM is installed on node MDM1.
 
 # version of installation package
-version = "1.32-2451.4"
+version = "1.32-3455.5"
 
 #OS Version of package
 os="el6"
+
+#ZIP OS Version of package
+zip_os="RHEL6"
 
 # installation folder
 siinstall = "/opt/scaleio/siinstall"
@@ -71,7 +74,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{tbip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/tb.sh"
-          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -c #{clusterinstall}"
+          s.args   = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -c #{clusterinstall}"
         end
       end
 
@@ -80,7 +83,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "forwarded_port", guest: 6611, host: 6611
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm1.sh"
-          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -p #{password} -c #{clusterinstall}"
+          s.args   = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -p #{password} -c #{clusterinstall}"
         end
       end
 
@@ -88,7 +91,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{secondmdmip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm2.sh"
-          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -t #{tbip} -p #{password} -c #{clusterinstall}"
+          s.args   = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -t #{tbip} -p #{password} -c #{clusterinstall}"
         end
       end
     end

--- a/scaleio/scripts/mdm1.sh
+++ b/scaleio/scripts/mdm1.sh
@@ -8,6 +8,10 @@ do
     OS="$2"
     shift
     ;;
+    -zo|--zipos)
+    ZIP_OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -54,11 +58,24 @@ echo PACKAGENAME    = "${PACKAGENAME}"
 echo FIRSTMDMIP    = "${FIRSTMDMIP}"
 echo SECONDMDMIP    = "${SECONDMDMIP}"
 echo CLUSTERINSTALL     = "${CLUSTERINSTALL}"
-#echo "Number files in SEARCH PATH with EXTENSION:" $(ls -1 "${SEARCHPATH}"/*."${EXTENSION}" | wc -l)
+echo ZIP_OS    = "${ZIP_OS}"
+
+VERSION_MAJOR=`echo "${VERSION}" | awk -F \. {'print $1'}`
+VERSION_MAJOR_MINOR=`echo "${VERSION}" | awk -F \. {'print $1"."$2'}`
+VERSION_MINOR=`echo "${VERSION}" | awk -F \. {'print $2'}`
+VERSION_MINOR_FIRST=`echo $VERSION_MINOR | awk -F "-" {'print $1'}`
+VERSION_MINOR_SUB=`echo $VERSION_MINOR | awk -F "-" {'print $2'}`
+VERSION_MINOR_SUB_FIRST=`echo $VERSION_MINOR_SUB | head -c 1`
+VERSION_SUMMARY=`echo $VERSION_MAJOR"."$VERSION_MINOR_FIRST"."$VERSION_MINOR_SUB_FIRST`
+
+echo VERSION_MAJOR = $VERSION_MAJOR
+echo VERSION_SUMMARY = $VERSION_SUMMARY
+
+
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
 yum install java-1.7.0-openjdk -y
-cd /vagrant/scaleio/ScaleIO_1.32.2_RHEL6_Download
+cd /vagrant/scaleio/ScaleIO_"$VERSION_SUMMARY"_"$ZIP_OS"_Download
 
 # Always install ScaleIO IM
 #export GATEWAY_ADMIN_PASSWORD=${PASSWORD}

--- a/scaleio/scripts/mdm2.sh
+++ b/scaleio/scripts/mdm2.sh
@@ -8,6 +8,10 @@ do
     OS="$2"
     shift
     ;;
+    -zo|--zipos)
+    ZIP_OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -61,10 +65,24 @@ echo SECONDMDMIP    = "${SECONDMDMIP}"
 echo TBIP    = "${TBIP}"
 echo PASSWORD    = "${PASSWORD}"
 echo CLUSTERINSTALL   =  "${CLUSTERINSTALL}"
+echo ZIP_OS    = "${ZIP_OS}"
+
+VERSION_MAJOR=`echo "${VERSION}" | awk -F \. {'print $1'}`
+VERSION_MAJOR_MINOR=`echo "${VERSION}" | awk -F \. {'print $1"."$2'}`
+VERSION_MINOR=`echo "${VERSION}" | awk -F \. {'print $2'}`
+VERSION_MINOR_FIRST=`echo $VERSION_MINOR | awk -F "-" {'print $1'}`
+VERSION_MINOR_SUB=`echo $VERSION_MINOR | awk -F "-" {'print $2'}`
+VERSION_MINOR_SUB_FIRST=`echo $VERSION_MINOR_SUB | head -c 1`
+VERSION_SUMMARY=`echo $VERSION_MAJOR"."$VERSION_MINOR_FIRST"."$VERSION_MINOR_SUB_FIRST`
+
+echo VERSION_MAJOR = $VERSION_MAJOR
+echo VERSION_SUMMARY = $VERSION_SUMMARY
+
+
 #echo "Number files in SEARCH PATH with EXTENSION:" $(ls -1 "${SEARCHPATH}"/*."${EXTENSION}" | wc -l)
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
-cd /vagrant/scaleio/ScaleIO_1.32.2_RHEL6_Download
+cd /vagrant/scaleio/ScaleIO_"$VERSION_SUMMARY"_"$ZIP_OS"_Download
 
 if [ "${CLUSTERINSTALL}" == "True" ]; then
   rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.${OS}.x86_64.rpm

--- a/scaleio/scripts/tb.sh
+++ b/scaleio/scripts/tb.sh
@@ -8,6 +8,10 @@ do
     OS="$2"
     shift
     ;;
+    -zo|--zipos)
+    ZIP_OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -50,13 +54,30 @@ echo PACKAGENAME    = "${PACKAGENAME}"
 echo FIRSTMDMIP    = "${FIRSTMDMIP}"
 echo SECONDMDMIP    = "${SECONDMDMIP}"
 echo CLUSTERINSTALL = "${CLUSTERINSTALL}"
-#echo "Number files in SEARCH PATH with EXTENSION:" $(ls -1 "${SEARCHPATH}"/*."${EXTENSION}" | wc -l)
+echo ZIP_OS    = "${ZIP_OS}"
+
+VERSION_MAJOR=`echo "${VERSION}" | awk -F \. {'print $1'}`
+VERSION_MAJOR_MINOR=`echo "${VERSION}" | awk -F \. {'print $1"."$2'}`
+VERSION_MINOR=`echo "${VERSION}" | awk -F \. {'print $2'}`
+VERSION_MINOR_FIRST=`echo $VERSION_MINOR | awk -F "-" {'print $1'}`
+VERSION_MINOR_SUB=`echo $VERSION_MINOR | awk -F "-" {'print $2'}`
+VERSION_MINOR_SUB_FIRST=`echo $VERSION_MINOR_SUB | head -c 1`
+VERSION_SUMMARY=`echo $VERSION_MAJOR"."$VERSION_MINOR_FIRST"."$VERSION_MINOR_SUB_FIRST`
+
+echo VERSION_MAJOR = $VERSION_MAJOR
+echo VERSION_SUMMARY = $VERSION_SUMMARY
+
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio wget -y
 cd /vagrant
-wget -nv http://downloads.emc.com/emc-com/usa/ScaleIO/ScaleIO_1.32.2_Linux_SW_Download.zip -O ScaleIO_RHEL6_Download.zip
-unzip -o ScaleIO_RHEL6_Download.zip -d /vagrant/scaleio/
-cd /vagrant/scaleio/ScaleIO_1.32.2_RHEL6_Download
+if [ ! -f "ScaleIO_Linux_"$VERSION_MAJOR".latest.zip" ];
+then
+  echo "Downloading SIO package from downloads.emc.com"
+  wget -nv http://downloads.emc.com/emc-com/usa/ScaleIO/ScaleIO_Linux_"$VERSION_MAJOR".latest.zip -O ScaleIO_Linux_"$VERSION_MAJOR".latest.zip
+fi
+unzip -o "ScaleIO_Linux_"$VERSION_MAJOR".latest.zip" -d /vagrant/scaleio/
+unzip -o "/vagrant/scaleio/ScaleIO_"$VERSION_SUMMARY"_"$ZIP_OS"_Download.zip" -d /vagrant/scaleio/
+cd /vagrant/scaleio/ScaleIO_"$VERSION_SUMMARY"_"$ZIP_OS"_Download
 
 if [ "${CLUSTERINSTALL}" == "True" ]; then
   rpm -Uv ${PACKAGENAME}-tb-${VERSION}.${OS}.x86_64.rpm


### PR DESCRIPTION
This commit introduces a change to ensure that ScaleIO updates
from the download link and versions are not statically configured.